### PR TITLE
add ability for user to customize the name of their index

### DIFF
--- a/lib/slate_algolia/extension.rb
+++ b/lib/slate_algolia/extension.rb
@@ -9,6 +9,7 @@ module Middleman
       option :parsers, {}, 'Custom tag parsers'
       option :dry_run, false, 'Send data to Algolia or not?'
       option :application_id, '', 'Algolia Application ID'
+      option :index_name, 'API Docs', 'Name for the Algolia Index'
       option :api_key, '', 'Algolia API Key'
       option :before_index, nil, 'A block to run on each record before it is sent to the index'
 
@@ -27,6 +28,7 @@ module Middleman
         @index ||= Index.new(
           application_id: options.application_id,
           api_key: options.api_key,
+          name: options.index_name,
           dry_run: options.dry_run,
           before_index: options.before_index
         )

--- a/lib/slate_algolia/index.rb
+++ b/lib/slate_algolia/index.rb
@@ -12,7 +12,7 @@ module Middleman
         Algolia.init application_id: @options[:application_id],
                      api_key: @options[:api_key]
 
-        @index = Algolia::Index.new('API Docs')
+        @index = Algolia::Index.new(options[:name])
         @queue = []
       end
 

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -5,11 +5,12 @@ describe Middleman::SlateAlgolia::Extension do
     :application_id,
     :api_key,
     :dry_run,
+    :index_name,
     :parsers,
     :before_index
   )
 
-  default_options = ConfigOptions.new('', '', false, {}, nil)
+  default_options = ConfigOptions.new('', '', false, 'API Docs', {}, nil)
 
   before :each do
     Given.fixture 'base'

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -10,6 +10,28 @@ describe Middleman::SlateAlgolia::Index do
     WebMock.reset!
   end
 
+  describe 'initialize' do
+    it 'creates an Algolia Index with the specified name' do
+      expect(Algolia::Index).to receive(:new).with('test')
+
+      Middleman::SlateAlgolia::Index.new(
+        application_id: '',
+        api_key: '',
+        name: 'test'
+      )
+    end
+
+    it 'uses the defined API keys for the Algolia Index' do
+      expect(Algolia).to receive(:init).with(application_id: 'id', api_key: 'key').and_call_original
+
+      Middleman::SlateAlgolia::Index.new(
+        application_id: 'id',
+        api_key: 'key',
+        name: ''
+      )
+    end
+  end
+
   describe 'flush_queue' do
     it 'calls before_index for each record' do
       dbl = double


### PR DESCRIPTION
## What does this PR do?

It adds a new configuration parameter to the extension for setting the name of the Algolia Index
## How should this be tested?

Step through the code line by line. Things to keep in mind as you review:
- `bundle exec rake`
- Try to build the base fixture with an `options.index_name = 'poop'`
