### PR TITLE
send object ID instead of id

### DIFF
--- a/lib/slate_algolia/extension.rb
+++ b/lib/slate_algolia/extension.rb
@@ -61,14 +61,14 @@ module Middleman
 
           h1: lambda do |node|
             {
-              id: node.get('id'),
+              objectID: node.get('id'),
               title: node.text
             }
           end,
 
           h2: lambda do |node|
             {
-              id: node.get('id'),
+              objectID: node.get('id'),
               title: node.text
             }
           end


### PR DESCRIPTION
## What does this PR do?

I made a bit of an oops, and named what _should_ be the unique identifier just `id`. Algolia expects it to be `objectId`. Whoops
## How should this be tested?

Step through the code line by line. Things to keep in mind as you review:
There's not really much to test here.
