### PR TITLE
Filter deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ activate :slate_algolia do |options|
 end
 ```
 
+## Filtering Deletes
+
+`slate_algolia` has automatic cleanup built in - meaning that after indexing new content, it will look through Algolia for any content that exists there but **does not** exist in the current content. It will remove those items, assuming they have been removed from the active content. However, you may not want to delete all of your unmatched records - perhaps they serve as a good synonym, or perhaps you index more than just slate docs in that Algolia index. There is a hook option you can use the filter out records from being deleted.
+
+```ruby
+active :slate_algolia do |options|
+  options.filter_deletes = proc { |record|
+    if record['category'] == 'API Docs'
+      true # Truthy values will be deleted
+    else
+      false # Non-Truthy values will be ignored
+    end
+  }
+end
+```
+
 
 ## Custom Tag Parser
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ end
 `slate_algolia` has automatic cleanup built in - meaning that after indexing new content, it will look through Algolia for any content that exists there but **does not** exist in the current content. It will remove those items, assuming they have been removed from the active content. However, you may not want to delete all of your unmatched records - perhaps they serve as a good synonym, or perhaps you index more than just slate docs in that Algolia index. There is a hook option you can use the filter out records from being deleted.
 
 ```ruby
-active :slate_algolia do |options|
+activate :slate_algolia do |options|
   options.filter_deletes = proc { |record|
     if record['category'] == 'API Docs'
       true # Truthy values will be deleted

--- a/lib/slate_algolia/extension.rb
+++ b/lib/slate_algolia/extension.rb
@@ -12,6 +12,7 @@ module Middleman
       option :index_name, 'API Docs', 'Name for the Algolia Index'
       option :api_key, '', 'Algolia API Key'
       option :before_index, nil, 'A block to run on each record before it is sent to the index'
+      option :filter_deletes, nil, 'A block to run on each record before it is deleted from the index'
 
       def initialize(app, options_hash = {}, &block)
         super
@@ -30,7 +31,8 @@ module Middleman
           api_key: options.api_key,
           name: options.index_name,
           dry_run: options.dry_run,
-          before_index: options.before_index
+          before_index: options.before_index,
+          filter_deletes: options.filter_deletes
         )
       end
 

--- a/lib/slate_algolia/index.rb
+++ b/lib/slate_algolia/index.rb
@@ -24,7 +24,11 @@ module Middleman
 
       def clean_index
         old_content = @index.browse['hits'].reject do |hit|
-          @published.any? { |entry| entry[:id] == hit['id'] }
+          @published.any? { |entry| entry[:id] == hit['objectID'] }
+        end
+
+        if @options[:filter_deletes].instance_of?(Proc)
+          old_content = run_filter_delete(old_content)
         end
 
         if @publish
@@ -47,6 +51,10 @@ module Middleman
         end
 
         @queue.flatten!
+      end
+
+      def run_filter_delete(all_records)
+        return all_records.select(&@options[:filter_deletes])
       end
 
       def flush_queue

--- a/slate_algolia.gemspec
+++ b/slate_algolia.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'slate_algolia'
-  s.version     = '1.0.0'
+  s.version     = '1.1.0'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Joe Wegner']
   s.email       = ['joe@wegnerdesign.com']
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   # The version of middleman-core your extension depends on
   s.add_runtime_dependency('middleman-core', ['~> 3.3', '>= 3.3.12'])
   s.add_runtime_dependency('oga', ['~> 1.3', '>= 1.3.1'])
-  s.add_runtime_dependency('algoliasearch', ['~> 1.6', '>= 1.6.1'])
+  s.add_runtime_dependency('algoliasearch', ['~> 1.12', '>= 1.12.5'])
 end

--- a/spec/extension_spec.rb
+++ b/spec/extension_spec.rb
@@ -7,7 +7,8 @@ describe Middleman::SlateAlgolia::Extension do
     :dry_run,
     :index_name,
     :parsers,
-    :before_index
+    :before_index,
+    :filter_deletes
   )
 
   default_options = ConfigOptions.new('', '', false, 'API Docs', {}, nil)

--- a/spec/index_spec.rb
+++ b/spec/index_spec.rb
@@ -128,4 +128,36 @@ describe Middleman::SlateAlgolia::Index do
       index.flush_queue
     end
   end
+
+  describe 'clean_index' do
+    it 'selects records using the :filter_deletes hook' do
+      index = Middleman::SlateAlgolia::Index.new(
+        application_id: '',
+        api_key: '',
+        dry_run: false,
+        filter_deletes: proc do |record|
+          record['objectID'] == "1"
+        end
+      )
+
+      instance_index = index.instance_variable_get('@index')
+
+      expect(instance_index).to receive(:delete_objects)
+        .with(['1'])
+      allow(instance_index).to receive(:browse) {
+        {
+          'hits' => [
+            {
+              'objectID' => '1'
+            },
+            {
+              'objectID' => '2'
+            }
+          ]
+        }
+      }
+        
+      index.clean_index
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do?

This does two things:

- Updates to the latest algolia ruby client (there were some big DDOS issues solved in the latest version)
- Adds a new extension option so that you can filter which records get deleted

## How should this be tested?

- run the specs
- Test this on your own slate docs, by setting `options.dry_run` to `true`.  That will output the number of records that will be deleted after the extension runs (dry run will **not** actually delete records). By adding a `filter_deletes` hook, you should be able to change the number of records deleted

(If you work at Keen and are reviewing this, chat with me and I help you set up a test in our docs)
## Related tickets?
