### PR TITLE
Bumping Middleman version to 4.0

### DIFF
--- a/lib/slate_algolia/extension.rb
+++ b/lib/slate_algolia/extension.rb
@@ -88,7 +88,8 @@ module Middleman
       private
 
       def parse_content
-        app.sitemap.where(:algolia_search.equal => true).all.each do |slate_page|
+        app.sitemap.resources.each do |slate_page|
+          next unless slate_page.data[:algolia_search]
           content_parser = Parser.new(slate_page, parsers)
           next if content_parser.sections.empty?
 

--- a/slate_algolia.gemspec
+++ b/slate_algolia.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   # The version of middleman-core your extension depends on
-  s.add_runtime_dependency('middleman-core', ['~> 3.3', '>= 3.3.12'])
+  s.add_runtime_dependency('middleman-core', ['~> 4.0', '>= 4.0.0'])
   s.add_runtime_dependency('oga', ['~> 1.3', '>= 1.3.1'])
   s.add_runtime_dependency('algoliasearch', ['~> 1.12', '>= 1.12.5'])
 end

--- a/spec/support/fixture.rb
+++ b/spec/support/fixture.rb
@@ -4,8 +4,8 @@ module Middleman
       def app(&block)
         ENV['MM_ROOT'] = Given::TMP
 
-        if Middleman::Application.respond_to?(:server)
-          app = Middleman::Application.server.inst do
+        if Middleman::Application.respond_to?(:new)
+          app = Middleman::Application.new do
             instance_eval(&block) if block
           end
         end


### PR DESCRIPTION
## What does this PR do?

This PR bumps the middleman gem requirement to 4.0.  Updating the gem version broke specs for 2 reasons:

1) `Middleman::Application.server.inst` isn't a thing in 4.0+, we should use `Middleman::Application.new` instead (in `spec/support/fixture.rb`)

2) Queryable Sitemap is gone in 4.0, so the code to iterate and parse the sitemap has to change (in `lib/slate_algolia/extension.rb`)

I'm assuming we would need to bump the gem version number here before merging this so we don't ruin anyone's afternoon 😄 

## How should this be tested?

I honestly have no idea how to test this. I plan on installing this gem on a dev version of site and hoping that nothing blows up.  Any feedback here would be greatly appreciated.  Let's consider this PR WIP as I hack my way through adding the updated gem to my site.

## Related tickets?

Issue #6 